### PR TITLE
Fix use cases where no profile name was needed

### DIFF
--- a/git-profile.sh
+++ b/git-profile.sh
@@ -113,10 +113,10 @@ check_directory() {
 PROFILENAME=None
 if [[ ! "$1" =~ ^- ]]; then
   PROFILENAME=$1
-else
-  error "Profile name must be passed as first argument!"
-  get_usage
-  exit 1
+# else
+#   error "Profile name must be passed as first argument!"
+#   get_usage
+#   exit 1
 fi
 
 # Script flags

--- a/git-profile.sh
+++ b/git-profile.sh
@@ -159,6 +159,12 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
 esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
+# Check if profile was being passed
+if [[ "$PROFILE_NAME" == "None "]]; then
+  error "Profile name not passed as first argument!"
+  exit 1
+fi
+
 # Check if git is present in the machine
 # if it's missing exit
 if [[ ! check_git ]]; then

--- a/git-profile.sh
+++ b/git-profile.sh
@@ -160,7 +160,7 @@ esac; shift; done
 if [[ "$1" == '--' ]]; then shift; fi
 
 # Check if profile was being passed
-if [[ "$PROFILE_NAME" == "None "]]; then
+if [[ "$PROFILE_NAME" == "None" ]]; then
   error "Profile name not passed as first argument!"
   exit 1
 fi


### PR DESCRIPTION
This PR fixes those use cases where the profile name was not needed.

For instance:

- `git-profile.sh --list`
- `git-profile.sh --save`
- `git-profile.sh --version`