### PR TITLE
Fix the profile list in the output

### DIFF
--- a/git-profile.sh
+++ b/git-profile.sh
@@ -93,7 +93,7 @@ list() {
   if [ -d "$PROFILE_DIR" ]; then
     profiles=(`ls ${PROFILE_DIR} | grep gitconfig | sed 's/\.gitconfig//g'`)
     if [ "${#profiles[@]}" -gt 0 ] ; then
-      info "Found ${#profiles[@]} profiles: ${profiles[@]}"
+      info "Found ${#profiles[@]} profiles: ${profiles[*]}"
       return 0
     else
       info "No profile found in $PROFILE_DIR"


### PR DESCRIPTION
The list command was returning the right number and only the first array item. This PR fixes this behavior and now the script returns all the array items.